### PR TITLE
Removed unnecessary use of local/parent.frame (fixes execution with compiler)

### DIFF
--- a/R/05makeBibLatex.R
+++ b/R/05makeBibLatex.R
@@ -1,6 +1,5 @@
 #' @keywords internal
-MakeBibLaTeX <- function(docstyle = "text", authortitle = FALSE) local({
-docstyle <- get("docstyle", parent.frame(2))
+MakeBibLaTeX <- function(docstyle = "text", authortitle = FALSE) {
 ##################################################################
 ## Formatting functions
 
@@ -1205,7 +1204,7 @@ formatUnpublished <- function(paper){
 }
 
 environment()
-})
+}
 
 # Convert BibEntry object to a fragment of Rd code.
 #

--- a/R/07makeBibLatexAuthoryear.R
+++ b/R/07makeBibLatexAuthoryear.R
@@ -1,6 +1,5 @@
 #' @keywords internal
-MakeAuthorYear <- function(docstyle = "text") local({
-  docstyle <- get("docstyle", parent.frame(2))
+MakeAuthorYear <- function(docstyle = "text"){
 ##################################################################
 ## Formatting functions
 
@@ -1144,4 +1143,4 @@ formatUnpublished <- function(paper){
 }
 
 environment()
-})
+}


### PR DESCRIPTION
This patch removes the unnecessary use of "parent.frame" at two locations in the source code. Functions like parent.frame should not be used unless absolutely necessary, because they are brittle: changes in R implementation may break the "number of frames" to count up. In this case, the use of "parent.frame(2)" works fine with the AST interpreter, but does not work with the bytecode compiler, because the bytecode compiler implements "local" differently (resulting in different number of frames on the stack). I've also removed an unnecessary call to "local" itself - the function/closure already provides the same level of encapsulation, so that:

  MakeBibLaTeX <- function(docstyle = "text") local({
    docstyle <- get("docstyle", parent.frame(2))
    sortKeys <- function() 42
    environment()
  })

becomes

  MakeBibLaTeX <- function(docstyle = "text") {
    sortKeys <- function() 42
    environment()
  }

With these fixes, the code works both with the R (AST) interpreter and the byte-code compiler.

