### PR TITLE
Fix mis-encoded `/`

### DIFF
--- a/R/ReadCrossRef.R
+++ b/R/ReadCrossRef.R
@@ -202,6 +202,7 @@ GetCrossRefBibTeX <- function(doi, tmp.file){
     return(1L)
   }
   temp <- gsub("&amp;", "&", temp, useBytes = TRUE)
+  temp <- gsub("%2F", "/", temp, useBytes = TRUE)
   ## Crossref uses data type for some entries
   temp <- sub("^@[Dd]ata", "@online", temp, useBytes = TRUE)
   write(temp, file = tmp.file, append=TRUE)


### PR DESCRIPTION
This fixes a problem that I mentioned in https://github.com/mwmclean/RefManageR/issues/7, where the return URL encodes a `/` as `%2F`, which subsequently fails to resolve.

The example here is:

```r
RefManageR::ReadCrossRef("10.1016/j.soncn.2006.01.010")
```

That works with but fails without the patch.