### PR TITLE
Bibtex months are expected in English

### DIFF
--- a/R/04InternalFunctions.R
+++ b/R/04InternalFunctions.R
@@ -945,41 +945,42 @@ ProcessDate <- function(dat, mon, searching = FALSE){
                if (length(days) == 2){
                   if (length(mons) == 1)
                     interval(parse_date_time(paste0(dats[1], "-", mons, "-", days[1]),
-                                                 c("%Y-%m-%d", "%Y-%b-%d")),
+                                                 c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"),
                                  parse_date_time(paste0(dats[2], "-", mons, "-", days[2]),
-                                                 c("%Y-%m-%d", "%Y-%b-%d")))
+                                                 c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"))
                   else if(length(mons) == 2)
                     interval(parse_date_time(paste0(dats[1], "-", mons[1], "-", days[1]),
-                                                 c("%Y-%m-%d", "%Y-%b-%d")),
+                                                 c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"),
                                  parse_date_time(paste0(dats[2], "-", mons[2], "-", days[2]),
-                                                 c("%Y-%m-%d", "%Y-%b-%d")))
+                                                 c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"))
                   else NA
               }else{
                 if (length(mons) == 1){
                   if (dats[1] == dats[2])
-                    parse_date_time(paste0(dat, "-", mons, "-", days), c("%Y-%m-%d", "%Y-%b-%d"))
+                    parse_date_time(paste0(dat, "-", mons, "-", days),
+                                    c("%Y-%m-%d", "%Y-%b-%d"), locale = "C")
                   else
                     interval(parse_date_time(paste0(dats[1], "-", mons, "-", days),
-                                                 c("%Y-%m-%d", "%Y-%b-%d")),
+                                                 c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"),
                                  parse_date_time(paste0(dats[2], "-", mons, "-", days),
-                                                 c("%Y-%m-%d", "%Y-%b-%d")))
+                                                 c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"))
                 }else if (length(mons) == 2)
                   interval(parse_date_time(paste0(dats[1], "-", mons[1], "-", days),
-                                               c("%Y-%m-%d", "%Y-%b-%d")),
+                                               c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"),
                                parse_date_time(paste0(dats[2], "-", mons[2], "-", days),
-                                               c("%Y-%m-%d", "%Y-%b-%d")))
+                                               c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"))
                 else NA
               }
           }else if (grepl("/", mon, useBytes = TRUE)){  # feb/mar
             mons <- strsplit(mon, "/")[[1L]]
-            interval(parse_date_time(paste0(dats[1], "-", mons[1], "-01"), c("%Y-%m-%d", "%Y-%b-%d")),
-                         parse_date_time(paste0(dats[2], "-", mons[2], "-01"), c("%Y-%m-%d", "%Y-%b-%d")))
+            interval(parse_date_time(paste0(dats[1], "-", mons[1], "-01"), c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"),
+                         parse_date_time(paste0(dats[2], "-", mons[2], "-01"), c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"))
           }else{
             if (dats[1] == dats[2])
-              parse_date_time(paste0(dat, '-', mon, '-01'), c("%Y-%m-%d", "%Y-%b-%d"))
+              parse_date_time(paste0(dat, '-', mon, '-01'), c("%Y-%m-%d", "%Y-%b-%d"), locale = "C")
             else
-              interval(parse_date_time(paste0(dats[1], '-', mon, '-01'), c("%Y-%m-%d", "%Y-%b-%d")),
-                           parse_date_time(paste0(dats[2], '-', mon, '-01'), c("%Y-%m-%d", "%Y-%b-%d")))
+              interval(parse_date_time(paste0(dats[1], '-', mon, '-01'), c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"),
+                           parse_date_time(paste0(dats[2], '-', mon, '-01'), c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"))
           }, TRUE)
       if (inherits(res, "try-error") || is.na(res)){
          warning(paste0("Failed to parse month: ", mon, ". Ignoring and using year only."))
@@ -995,7 +996,7 @@ ProcessDate <- function(dat, mon, searching = FALSE){
 
   }else if (grepl('^(1|2)[0-9]{3}/$', dat, useBytes = TRUE)){
     if (!is.null(mon)){
-      res <- interval(parse_date_time(paste0(substring(dat, 1, 4), '-', mon, '-01'), c("%Y-%m-%d", "%Y-%b-%d")),
+      res <- interval(parse_date_time(paste0(substring(dat, 1, 4), '-', mon, '-01'), c("%Y-%m-%d", "%Y-%b-%d"), locale = "C"),
                           Sys.Date())
       .mon <- TRUE
     }else{


### PR DESCRIPTION
Most bibtex entries are in English, so we should expect the months to be in English as well. `lubridate::parse_date_time` uses the current locale instead of the English "C" locale.

When I get a bib entry from its DOI using `DOIRefManageR::GetBibEntryWithDOI("10.1016/j.cccn.2004.04.023")`, the year and month are specified as "2004" and "sep" respectively.

I get a warning when I try to print the entry. I have traced the warning to this function call:

```
RefManageR:::ProcessDate("2004", "sep")
#[1] "2004-01-01 CET"
#Warning messages:
#1: All formats failed to parse. No formats found. 
#2: In RefManageR:::ProcessDate("2004", "sep") :
# Failed to parse month: sep. Ignoring and using year only.
```

This issue happens because my locale is not English, so this is my workaround:

```
Sys.setlocale(locale="C") # default C locale
RefManageR:::ProcessDate("2004", "sep")
[1] "2004-09-01 UTC"
```

This PR tells lubridate to use the English locale to parse the month, fixing this issue.